### PR TITLE
[clipper.cpp] fix Visual Studio 2008 error C2668: 'abs': ambiguous call to overloaded function

### DIFF
--- a/cppWrapper/clipper.cpp
+++ b/cppWrapper/clipper.cpp
@@ -38,7 +38,7 @@
 #include <cstdlib>
 
 //Workaround for older compilers that don't have std::abs
-#if (__GNUC__ == 2 && __GNUC_MINOR__ <= 97) || (defined(BOOST_MSVC) && _MSC_VER <= 1200)
+#if (__GNUC__ == 2 && __GNUC_MINOR__ <= 97) || (defined(_MSC_VER) && _MSC_VER < 1600)
 namespace std
 {
     long long abs(long long x) { return x < 0 ? -x : x; }


### PR DESCRIPTION
The C++ compiler in Microsoft Visual Studio 2008 (i.e. `_MSC_VER == 1500`) does not define `std::abs(long long)`. Visual Studio 2010 (`_MSC_VER == 1600`) does contain it, so we don't need to redefine it.

See a similar disscussion here: https://bugzilla.mozilla.org/show_bug.cgi?id=818391.

Visual Studio 2008 is no longer supported by Microsoft, however all the Python 2.7 distributions for Windows (at least the ones from Python.org) are still compiled with it for compatibility with existing extension modules. In fact, the latter must be compiled using the same version of Visual Studio which was used to build the main Python interpreter, to avoid conflicts between different versions of the Microsoft C runtime.

Microsoft provides a "Visual C++ Compiler 9.0 for Python", which is the same as the one from Visual Studio 2008: https://www.microsoft.com/en-gb/download/details.aspx?id=44266

We need this patch to allow Windows Python 2.7 users to compile the `pyClipper.pyd` Cython wrapper required by booleanOperations.

Thanks.