### PR TITLE
Fix typos in BooleanContour class

### DIFF
--- a/Lib/booleanOperations/booleanGlyph.py
+++ b/Lib/booleanOperations/booleanGlyph.py
@@ -68,7 +68,7 @@ class BooleanContour(object):
         if self._clockwise is None:
             pointPen = ClockwiseTestPointPen()
             self.drawPoints(pointPen)
-            self._clockwiseCache = pointPen.getIsClockwise()
+            self._clockwise = pointPen.getIsClockwise()
         return self._clockwise
 
     clockwise = property(_get_clockwise)
@@ -78,7 +78,7 @@ class BooleanContour(object):
             from robofab.pens.boundsPen import BoundsPen
             pen = BoundsPen(None)
             self.draw(pen)
-            self._boundsCache = pen.bounds
+            self._bounds = pen.bounds
         return self._bounds
 
     bounds = property(_get_bounds)


### PR DESCRIPTION
Both _boundsCache and _clockwiseCache seem to be typos as they are
unseen anywhere else, no idea if this ever worked (it have been like
that since the first commit). Thanks to @anthrotype for finding this,
for more details see:
https://github.com/adobe-type-tools/afdko/issues/80