### PR TITLE
set up Travis CI for testing OS X build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "terryfy"]
+	path = terryfy
+	url = https://github.com/MacPython/terryfy.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+os:
+  - osx
+env:
+  matrix:
+  - INSTALL_TYPE='macpython' VERSION=2.7.10 CC=clang CXX=clang++
+  - INSTALL_TYPE='macpython' VERSION=3.4.3 CC=clang CXX=clang++
+  - INSTALL_TYPE='macpython' VERSION=3.5.0 CC=clang CXX=clang++
+install:
+  - source terryfy/travis_tools.sh
+  - get_python_environment $INSTALL_TYPE $VERSION venv
+  - $PIP_CMD install --upgrade wheel
+  - $PIP_CMD install cython
+script:
+  - $PIP_CMD wheel -v -w . .
+after_success:
+  - $PYTHON_EXE setup.py sdist -d . --formats=gztar,zip
+before_deploy:
+  - export GZTAR=$(ls *.tar.gz)
+  - export ZIP=$(ls *.zip)
+  - export WHL=$(ls *.whl)
+# deploy:
+#   provider: releases
+#   api_key:
+#     secure: <put your GitHub API key here>
+#   file:
+#     - "${GZTAR}"
+#     - "${ZIP}"
+#     - "${WHL}"
+#   skip_cleanup: true
+#   on:
+#     repo: typemytype/booleanOperations
+#     tags: true


### PR DESCRIPTION
This sets up Travis CI for testing compilation on Python 2.7, 3.4 and 3.5 on OS X.

I use the [MacPython/terrify](https://github.com/MacPython/terryfy) utilities to automatically install the official Python versions from Python.org, and run the build in a newly created virtual environment.

@typemytype I have commented out the `deploy` section in the `.travis.yml` file because you'll need to activate Travis CI for the booleanOperations repo first, and then also generate an encrypted GitHub API key to paste in the `.travis.yml` file. This will allow to upload the pre-compiled packages directly to the repo's Releases page upon any new tag.

@readroberts maybe you can have a look at the Travis build log and see if this can help you sort out your issue https://github.com/typemytype/booleanOperations/issues/12.

https://travis-ci.org/anthrotype/booleanOperations/builds/89755109