### PR TITLE
Streamline build and installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,15 @@ If the wheel isn't available, pip will attempt to compile the package from the s
 Build
 -----
 
-The included `setup.py` file operates in one of two modes depending on the presence/absence of an empty file named `dev` in the project root directory.
+The extension module is generated using [Cython](http://cython.org/). 
 
-When the file is present, as in the Github repository, then [Cython](http://cython.org/) is required in order to convert the `.pyx` files to `.cpp`.
+The source distributions already contain a pre-generated `pyClipper.cpp` file, thus only a C++ compiler is required to build the extension module.
 
-In the source distributions this 'dev' file is missing, and pre-generated `.cpp` files are present instead.
+Since this file is not stored in the git repository, if you want to build from a cloned repository, you will also need Cython in order to generate the `.cpp` source file.
 
-This mechanism allows source distributions to be installed on systems which don't have Cython, or have a different versions (the idea comes from <https://github.com/MattShannon/bandmat>).
+The `setup.py` script will automatically fetch and install Cython locally (to a temporary "./.eggs" folder) if Cython is not already installed and the pre-generated C++ file is absent.
 
-In both cases a C++ compiler is needed to build the Python extension module.
-
-For example, to compile it in the same location as the Python sources:
+To compile the module in the same location as the Python sources:
 
 ```
 python setup.py build_ext --inplace

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,8 +48,8 @@ install:
   # upgrade pip to avoid out-of-date warnings
   - "pip install --disable-pip-version-check --user --upgrade pip"
 
-  # install wheel and Cython to build compiled packages
-  - "pip install --upgrade wheel cython"
+  # install/upgrade setuptools, wheel and Cython to build compiled packages
+  - "pip install --upgrade setuptools wheel cython"
 
 build: false
 


### PR DESCRIPTION
I removed the empty `dev` file hack and simplified the installation process.

I now use setuptools (rather than distutils) to resolve the Cython dependency.

Setuptools is installed almost everywhere along with the pip installer, and it's the recommended way to distribute Python packages by the PyPA (Python Packaging Authority).

I require setuptools >= 18.0, because only with the latter they introduced support for specifying Cython as part of `setup_requires` argument (cf. https://bitbucket.org/pypa/setuptools/commits/424966904023#chg-CHANGES.txt).

It's now very easy to build the booleanOperation module, either from source distribution (.tar.gz or .zip with pre-generated `pyClipper.cpp` file) or from a cloned git repository (where only `pyClipper.pyx` file is present and thus Cython is required).

When Cython is required and is not already installed, the setup.py script takes care of fetching and installing Cython locally (in a temporary "./.eggs" folder) before proceeding to compile the C++ sources.

Both Travis and Appveyor builds complete without errors:
https://ci.appveyor.com/project/anthrotype/booleanoperations/build/1.0.9
https://travis-ci.org/anthrotype/booleanOperations/builds/97731488




