### PR TITLE
store `__version__` inside __init__.py and have setup.py read from there

### DIFF
--- a/Lib/booleanOperations/__init__.py
+++ b/Lib/booleanOperations/__init__.py
@@ -1,2 +1,4 @@
 from __future__ import print_function, division, absolute_import
 from .booleanOperationManager import BooleanOperationManager
+
+__version__ = "0.2"

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,14 @@
 from __future__ import print_function
 import sys
 import os
+import re
 
-__version__ = "0.2"
+version = ''
+with open('Lib/booleanOperations/__init__.py', 'r') as fd:
+    version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
+                        fd.read(), re.MULTILINE).group(1)
+if not version:
+    raise RuntimeError('Cannot find version information')
 
 try:
     import pkg_resources
@@ -85,7 +91,7 @@ ext_module = Extension(
 
 setup(
     name="booleanOperations",
-    version=__version__,
+    version=version,
     description="Boolean operations on paths.",
     author="Frederik Berlaen",
     author_email="frederik@typemytype.com",


### PR DESCRIPTION
So one can get the version string like that:
```
import booleanOperations
print(booleanOperations.__version__)
```

and we can set it only once and have the metadata in setup.py update automatically.

(Actually, I did this just to see if the Travis and Appveyor start up when opening a pull request... ;)