### PR TITLE
README.md: mention the python versions supported by the wheels

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install --find-links https://github.com/typemytype/booleanOperations/release
 
 Pip will first try to download the Python [wheel](http://pythonwheels.com/) archive that was compiled for your platform and Python version.
 
-For the current version, wheels are only available for **Python 2.7** on **OS X** (10.6 and above) and **Windows** (32-bit).
+Wheels are available for **OS X** (`intel`) and **Windows** (`win32`) platforms, for Python **2.7**, **3.4** and **3.5**.
 
 If the wheel isn't available, pip will attempt to compile the package from the source distribution (`.tar.gz` or `.zip`).
 


### PR DESCRIPTION
README didn't mention that we also provide wheels for python 3.4 and 3.5.