### PR TITLE
use @staticmethod for BooleanOperationManager and export top-level functions

### DIFF
--- a/Lib/booleanOperations/__init__.py
+++ b/Lib/booleanOperations/__init__.py
@@ -2,3 +2,10 @@ from __future__ import print_function, division, absolute_import
 from .booleanOperationManager import BooleanOperationManager
 
 __version__ = "0.2"
+
+# export BooleanOperationManager static methods
+union = BooleanOperationManager.union
+difference = BooleanOperationManager.difference
+intersection = BooleanOperationManager.intersection
+xor = BooleanOperationManager.xor
+getIntersections = BooleanOperationManager.getIntersections

--- a/Lib/booleanOperations/__init__.py
+++ b/Lib/booleanOperations/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division, absolute_import
 from .booleanOperationManager import BooleanOperationManager
 
-__version__ = "0.2"
+__version__ = "0.3"
 
 # export BooleanOperationManager static methods
 union = BooleanOperationManager.union


### PR DESCRIPTION
As suggested by @behdad in #24.

This maintains retro-compatibility with the current API, but also allows to use `union`, `difference`, `intersection`, `xor`, and `getIntersections` methods as normal functions available from the top-level `booleanOperations` module, without having to first create a BooleanOperationManager object.