### PR TITLE
use setuptools_scm to manage package version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ Lib/booleanOperations.egg-info
 .eggs
 
 .DS_Store
+
+.tox/
+.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ python:
 install:
   - pip install --upgrade pip setuptools wheel
   - pip install tox-travis
+  # Travis by default only clones a 'shallow' repository with --depth=50.
+  # When building the distribution packages, we use git to determine the
+  # package version string (via setuptools_scm), hence we need to fetch
+  # the whole repo, and not just the last 50 commits.
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then git fetch --unshallow; fi
 script: tox
 after_success:
   - pip wheel --no-deps -w dist .

--- a/Lib/booleanOperations/__init__.py
+++ b/Lib/booleanOperations/__init__.py
@@ -1,8 +1,6 @@
 from __future__ import print_function, division, absolute_import
 from .booleanOperationManager import BooleanOperationManager
 
-__version__ = "0.5.1"
-
 # export BooleanOperationManager static methods
 union = BooleanOperationManager.union
 difference = BooleanOperationManager.difference

--- a/Lib/booleanOperations/version.py
+++ b/Lib/booleanOperations/version.py
@@ -1,0 +1,4 @@
+try:
+    __version__ = __import__('pkg_resources').require('booleanOperations')[0].version
+except Exception:
+    __version__ = 'unknown'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,1 @@
-include MANIFEST.in LICENSE README.md
-include setup.py requirements.txt setup.cfg tox.ini
-recursive-include Lib *.py
-recursive-include tests *.py
+exclude .travis.yml appveyor.yml .gitignore

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,5 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 import sys
-import re
-
-version = ''
-with open('Lib/booleanOperations/__init__.py', 'r') as fd:
-    version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
-                        fd.read(), re.MULTILINE).group(1)
-if not version:
-    raise RuntimeError('Cannot find version information')
 
 needs_pytest = {'pytest', 'test'}.intersection(sys.argv)
 pytest_runner = ['pytest_runner'] if needs_pytest else []
@@ -19,16 +11,18 @@ with open('README.md', 'r') as f:
 
 setup_params = dict(
     name="booleanOperations",
-    version=version,
+    use_scm_version=True,
     description="Boolean operations on paths.",
     long_description=long_description,
     author="Frederik Berlaen",
     author_email="frederik@typemytype.com",
     url="https://github.com/typemytype/booleanOperations",
     license="MIT",
-    packages=["booleanOperations"],
     package_dir={"": "Lib"},
-    setup_requires=pytest_runner + wheel,
+    packages=find_packages("Lib"),
+    setup_requires=[
+        "setuptools_scm>=1.11.1",
+    ] + pytest_runner + wheel,
     tests_require=[
         'pytest>=3.0.2',
     ],


### PR DESCRIPTION
Same as https://github.com/behdad/fonttools/pull/648

we no longer need to manually write the package version, as that will be generated automatically from the current git tag, as well as the relative distance from it.

When you push new commits, the last digit in the version string is incremented +1, and a pre-release suffix `.dev1`, `.dev2`, ... `.dev940` is also appended that indicate how many commits intervened since the previous tag.

When you push a new tag (i.e. make a release), the suffix is dropped and the version string becomes the new tag.

Just release, and never think about it.