### PR TITLE
raise custom exceptions when pyclipper fails

### DIFF
--- a/Lib/booleanOperations/__init__.py
+++ b/Lib/booleanOperations/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division, absolute_import
 from .booleanOperationManager import BooleanOperationManager
-from .exceptions import Error
+from .exceptions import BooleanOperationsError
 
 # export BooleanOperationManager static methods
 union = BooleanOperationManager.union

--- a/Lib/booleanOperations/__init__.py
+++ b/Lib/booleanOperations/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 from .booleanOperationManager import BooleanOperationManager
+from .exceptions import Error
 
 # export BooleanOperationManager static methods
 union = BooleanOperationManager.union

--- a/Lib/booleanOperations/exceptions.py
+++ b/Lib/booleanOperations/exceptions.py
@@ -1,0 +1,21 @@
+from __future__ import print_function, division, absolute_import
+
+
+class Error(Exception):
+    """Base BooleanOperations exception"""
+
+
+class InvalidContourError(Error):
+    """Rased when any input contour is invalid"""
+
+
+class InvalidSubjectContourError(InvalidContourError):
+    """Rased when a 'subject' contour is not valid"""
+
+
+class InvalidClippingContourError(InvalidContourError):
+    """Rased when a 'clipping' contour is not valid"""
+
+
+class ExecutionError(Error):
+    """Raised when clipping execution fails"""

--- a/Lib/booleanOperations/exceptions.py
+++ b/Lib/booleanOperations/exceptions.py
@@ -1,11 +1,11 @@
 from __future__ import print_function, division, absolute_import
 
 
-class Error(Exception):
+class BooleanOperationsError(Exception):
     """Base BooleanOperations exception"""
 
 
-class InvalidContourError(Error):
+class InvalidContourError(BooleanOperationsError):
     """Rased when any input contour is invalid"""
 
 
@@ -17,5 +17,5 @@ class InvalidClippingContourError(InvalidContourError):
     """Rased when a 'clipping' contour is not valid"""
 
 
-class ExecutionError(Error):
+class ExecutionError(BooleanOperationsError):
     """Raised when clipping execution fails"""


### PR DESCRIPTION
When an invalid contour is received as a subject or clipping path, `pyclipper` raises its own `ClipperException` error.

I wouldn't want clients to have to import pyclipper in order to handle the exception. I believe that should stay private as we may decide to replace pyclipper with another implementation in the future. 

So we need to define our own custom exceptions, and re-raise the `pyclipper.ClipperException` as `booleanOperations.BooleanOperationsError`.

For example, one could do:

```python
import booleanOperations

try:
    # perform some booleanOpertions
except booleanOperations.BooleanOperationsError:
    # handle the exception
```

The custom errors are defined in the `booleanOperations.exceptions` module. For convenience, the generic one is also exported in the top-level module as `booleanOperations.BooleanOperationsError`.

Note that previously, we were calling pyclipper's `AddPaths` method, which only raised when _all_ the input path are invalid; I replaced it with `AddPath` (in a loop), so we can raise when _any_ input path is invalid, and report which one in the exception message, so the user can find it more easily.

