### PR TITLE
flatten: convert 'flat' curves to lines if off-curves are aligned with on-curves

### DIFF
--- a/Lib/booleanOperations/flatten.py
+++ b/Lib/booleanOperations/flatten.py
@@ -147,7 +147,7 @@ class InputSegment(object):
         self.scaledPreviousOnCurve = _scaleSinglePoint(previousOnCurve, scale=clipperScale)
         self.used = False
         self.flat = []
-        # if the bcps are equal to the oncurves convert the segment to a line segment.
+        # if the bcps are equal to the oncurves, or are aligned with them, convert the segment to a line segment.
         # otherwise this causes an error when flattening.
         if self.segmentType == "curve":
             if previousOnCurve == points[0].coordinates and points[1].coordinates == points[-1].coordinates:
@@ -159,6 +159,11 @@ class InputSegment(object):
                 oncurve.segmentType = "line"
                 self.points = points = [oncurve]
             elif previousOnCurve[1] == points[0].coordinates[1] == points[1].coordinates[1] == points[-1].coordinates[1]:
+                oncurve = points[-1]
+                oncurve.segmentType = "line"
+                self.points = points = [oncurve]
+            elif (_pointOnLine(previousOnCurve, points[-1].coordinates, points[0].coordinates) and
+                  _pointOnLine(previousOnCurve, points[-1].coordinates, points[1].coordinates)):
                 oncurve = points[-1]
                 oncurve.segmentType = "line"
                 self.points = points = [oncurve]


### PR DESCRIPTION
This is an attempt at fixing https://github.com/googlei18n/fontmake/issues/180

@typemytype could you please have a look?

it appears like when a curve segment is "flat", i.e. the offcurves are on the same line connecting the previous and current on-curve, and it happens to be the last segment in the output contour, sometimes it can end up being dropped altogether, as shown in the above mentioned fontmake issue.

The glyph in question, which prompted this bug, is the following:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<glyph name="uniA73A" format="2">
  <advance width="797"/>
  <unicode hex="A73A"/>
  <outline>
    <contour>
      <point x="0" y="0" type="line"/>
      <point x="29" y="0" type="line"/>
      <point x="245" y="593" type="line" smooth="yes"/>
      <point x="255" y="620"/>
      <point x="267" y="652"/>
      <point x="277" y="682" type="curve"/>
      <point x="289" y="645"/>
      <point x="299" y="617"/>
      <point x="307" y="594" type="curve" smooth="yes"/>
      <point x="515" y="0" type="line"/>
      <point x="544" y="0" type="line"/>
      <point x="797" y="714" type="line"/>
      <point x="767" y="714" type="line"/>
      <point x="567" y="143" type="line" smooth="yes"/>
      <point x="554" y="107"/>
      <point x="542" y="73"/>
      <point x="530" y="40" type="curve"/>
      <point x="517" y="76"/>
      <point x="504" y="112"/>
      <point x="491" y="148" type="curve" smooth="yes"/>
      <point x="291" y="716" type="line"/>
      <point x="265" y="716" type="line"/>
    </contour>
    <contour>
      <point x="146" y="344" type="line"/>
      <point x="655" y="344" type="line"/>
      <point x="655" y="369" type="line"/>
      <point x="146" y="369" type="line"/>
    </contour>
  </outline>
</glyph>
```

The `mergeFirstSegments` logic in the (extremely complicated) `OutputContour.reCurveSubSegments` method seems to be responsible for popping up the last segment.
https://github.com/typemytype/booleanOperations/blob/master/Lib/booleanOperations/flatten.py#L765-L803

If the segmentType of such "flat" curves is set to be "line" (because that's what they actually are), then they will be kept.

I hope that makes sense.