### PR TITLE
[flatten] record position of contour's starting point and restore if possible

### DIFF
--- a/Lib/booleanOperations/flatten.py
+++ b/Lib/booleanOperations/flatten.py
@@ -973,15 +973,17 @@ class OutputContour(object):
             points.extend(segment.points)
 
         hasOnCurve = False
-        foundOriginalStartingPoint = False
+        originalStartingPoints = []
         for index, point in enumerate(points):
             if point.segmentType is not None:
                 hasOnCurve = True
                 if point.kwargs is not None and point.kwargs.get("startingPoint"):
-                    foundOriginalStartingPoint = True
-                    break
-        if foundOriginalStartingPoint:
-            points = points[index:] + points[:index]
+                    distanceFromOrigin = math.hypot(*point)
+                    originalStartingPoints.append((distanceFromOrigin, index))
+        if originalStartingPoints:
+            # use the original starting point that is closest to the origin
+            startingPointIndex = sorted(originalStartingPoints)[0][1]
+            points = points[startingPointIndex:] + points[:startingPointIndex]
         elif hasOnCurve:
             while points[0].segmentType is None:
                 p = points.pop(0)

--- a/Lib/booleanOperations/flatten.py
+++ b/Lib/booleanOperations/flatten.py
@@ -306,6 +306,7 @@ class ContourPointDataPen:
 
     def __init__(self):
         self._points = None
+        self._foundStartingPoint = False
 
     def getData(self):
         """
@@ -343,6 +344,8 @@ class ContourPointDataPen:
 
     def addPoint(self, pt, segmentType=None, smooth=False, name=None, **kwargs):
         assert segmentType != "move"
+        if not self._foundStartingPoint and segmentType is not None:
+            kwargs['startingPoint'] = self._foundStartingPoint = True
         data = InputPoint(
             coordinates=pt,
             segmentType=segmentType,
@@ -970,11 +973,16 @@ class OutputContour(object):
             points.extend(segment.points)
 
         hasOnCurve = False
-        for point in points:
+        foundOriginalStartingPoint = False
+        for index, point in enumerate(points):
             if point.segmentType is not None:
                 hasOnCurve = True
-                break
-        if hasOnCurve:
+                if point.kwargs is not None and point.kwargs.get("startingPoint"):
+                    foundOriginalStartingPoint = True
+                    break
+        if foundOriginalStartingPoint:
+            points = points[index:] + points[:index]
+        elif hasOnCurve:
             while points[0].segmentType is None:
                 p = points.pop(0)
                 points.append(p)


### PR DESCRIPTION
I noticed that sometimes booleanOperations doesn't keep the original position of the starting point after removing overlaps, even when the original point is still there and is not clipped away.

This patch makes makes so that we record the position of the starting point as we read in input contours, and we attempt to restore it when drawing the output contours, after the clipping has occurred.

I do that by setting a `startingPoint=True` keyword argument on that point when reading the input contours, and getting that attribute later on inside `drawPoints` method of the output contours.

/cc @typemytype 