### PR TITLE
simplify handling of invalid zero-area paths

### DIFF
--- a/Lib/booleanOperations/booleanOperationManager.py
+++ b/Lib/booleanOperations/booleanOperationManager.py
@@ -30,34 +30,25 @@ _fillTypeMap = {
 }
 
 
-def _addContour(clipperPath, contour, fillType, contourCount):
-    if pyclipper.Area(contour) == 0:
-        # skip paths with no area,
-        # BUT self intersecting paths could have no area...
-        dummy = pyclipper.Pyclipper()
-        try:
-            dummy.AddPath(contour, fillType)
-            shouldBeAValidPath = True
-        except pyclipper.ClipperException:
-            shouldBeAValidPath = False
-        if not shouldBeAValidPath:
-            return
-
-    try:
-        clipperPath.AddPath(contour, fillType)
-    except pyclipper.ClipperException:
-        raise InvalidSubjectContourError("contour %d is invalid for clipping" % contourCount)
-
-
 def clipExecute(subjectContours, clipContours, operation, subjectFillType="nonZero",
                 clipFillType="nonZero"):
     pc = pyclipper.Pyclipper()
 
     for i, subjectContour in enumerate(subjectContours):
-        _addContour(clipperPath=pc, contour=subjectContour, fillType=pyclipper.PT_SUBJECT, contourCount=i)
+        try:
+            pc.AddPath(subjectContour, pyclipper.PT_SUBJECT)
+        except pyclipper.ClipperException:
+            # skip invalid paths with no area
+            if pyclipper.Area(subjectContour) != 0:
+                raise InvalidSubjectContourError("contour %d is invalid for clipping" % i)
 
     for j, clipContour in enumerate(clipContours):
-        _addContour(clipperPath=pc, contour=clipContour, fillType=pyclipper.PT_CLIP, contourCount=i)
+        try:
+            pc.AddPath(clipContour, pyclipper.PT_CLIP)
+        except pyclipper.ClipperException:
+            # skip invalid paths with no area
+            if pyclipper.Area(clipContour) == 0:
+                raise InvalidClippingContourError("contour %d is invalid for clipping" % j)
 
     bounds = pc.GetBounds()
     if (bounds.bottom, bounds.left, bounds.top, bounds.right) == (0, 0, 0, 0):


### PR DESCRIPTION
follow up from https://github.com/typemytype/booleanOperations/pull/51

this does the same thing (i.e. ignore invalid paths when they have 0 area, but do include valid 0-area paths e.g. self-intersecting ones), without the need to instantiate a dummy Pyclipper instance.