### PR TITLE
Raise new UnsupportedContourError on unsupported segment type

### DIFF
--- a/Lib/booleanOperations/exceptions.py
+++ b/Lib/booleanOperations/exceptions.py
@@ -5,6 +5,10 @@ class BooleanOperationsError(Exception):
     """Base BooleanOperations exception"""
 
 
+class UnsupportedContourError(BooleanOperationsError):
+    """Raised when asked to perform an operation on an unsupported curve type."""
+
+
 class InvalidContourError(BooleanOperationsError):
     """Raised when any input contour is invalid"""
 

--- a/Lib/booleanOperations/flatten.py
+++ b/Lib/booleanOperations/flatten.py
@@ -3,7 +3,7 @@ import math
 from fontTools.misc import bezierTools
 from fontTools.pens.basePen import decomposeQuadraticSegment
 import pyclipper
-from .exceptions import OpenContourError
+from .exceptions import OpenContourError, UnsupportedContourError
 
 """
 To Do:
@@ -434,7 +434,7 @@ def _convertPointsToSegments(points, willBeReversed=False):
         # off curve, hold.
         if point.segmentType is None:
             offCurves.append(point)
-        else:
+        elif point.segmentType in {"curve", "line"}:
             segment = InputSegment(
                 points=offCurves + [point],
                 previousOnCurve=previousOnCurve,
@@ -443,6 +443,11 @@ def _convertPointsToSegments(points, willBeReversed=False):
             segments.append(segment)
             offCurves = []
             previousOnCurve = point.coordinates
+        else:
+            raise UnsupportedContourError(
+                "Trying to perform operation on unsupported segment type.",
+                point.segmentType
+            )
     assert not offCurves
     return segments
 

--- a/tests/test_BooleanGlyph.py
+++ b/tests/test_BooleanGlyph.py
@@ -4,6 +4,7 @@ import sys
 import os
 import unittest
 
+import pytest
 from fontPens.digestPointPen import DigestPointPen
 
 import defcon
@@ -78,6 +79,20 @@ def _addGlyphTests():
 
 _addGlyphTests()
 
+def test_unsupported_qcurve():
+    font = defcon.Font()
+    g = font.newGlyph("test")
+    p = g.getPointPen()
+    p.beginPath()
+    p.addPoint((0, 0), segmentType="line")
+    p.addPoint((100, 0), segmentType="line")
+    p.addPoint((100, 100), segmentType="line")
+    p.addPoint((50, 100))
+    p.addPoint((0, 100), segmentType="qcurve")
+    p.endPath()
+
+    with pytest.raises(booleanOperations.exceptions.UnsupportedContourError):
+        booleanOperations.union(g, None)
 
 if __name__ == '__main__':
     sys.exit(unittest.main())

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     fontPens
     pytest
     -rrequirements.txt
+download = True
 commands =
     # pass to pytest any extra positional arguments after `tox -- ...`
     pytest {posargs}


### PR DESCRIPTION
This allows ufo2ft to easily catch the error and display a meaningful error message, including which glyph caused the explosion.