### PR TITLE
Remove wheel from setup_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ packages = find:
 python_requires = >=3.6
 setup_requires =
     setuptools_scm
-    wheel
 install_requires =
     pyclipper >= 1.1.0.post1
     fonttools >= 4.0.2


### PR DESCRIPTION
When downloading the source and building this locally python-wheel is not required. It is only required for developers who build bdist packages for publishing. The CI jobs that do this already manually install wheel anyway and most documentation I see assumes that will be the case. For distro packagers, having this in here just means we have to include an unused dependency or patch it out.