### PR TITLE
Correct for (rare) bad tracking of previousIntersectionPoint

### DIFF
--- a/Lib/booleanOperations/flatten.py
+++ b/Lib/booleanOperations/flatten.py
@@ -255,6 +255,29 @@ class InputSegment:
         else:
             raise NotImplementedError
 
+    def tValueToPoint(self, t):
+        if self.segmentType == "curve":
+            on1 = self.previousOnCurve
+            off1 = self.points[0].coordinates
+            off2 = self.points[1].coordinates
+            on2 = self.points[2].coordinates
+            return _getCubicPoint(t, on1, off1, off2, on2)
+        elif self.segmentType == "line":
+            return _getLinePoint(t, self.previousOnCurve, self.points[0].coordinates)
+        elif self.segmentType == "qcurve":
+            raise NotImplementedError
+        else:
+            raise NotImplementedError
+
+    def hasPoint(self, p):
+        if p is None:
+            return False
+        for t in self.tValueForPoint(p):
+            pp = self.tValueToPoint(t)
+            if _distance(p, pp) < _approximateSegmentLength/100:
+                return True
+        return False
+
 
 class InputPoint:
 
@@ -803,6 +826,13 @@ class OutputContour:
                         continue
                     tValues = None
                     lastPointWithAttributes = None
+                    # Occasionally our logic about the previous intersection
+                    # point can drift out of sync with the current segment.
+                    # So check here if it is on the current segment and if
+                    # not set it to None
+                    if not inputSegment.hasPoint(previousIntersectionPoint):
+                        previousIntersectionPoint = None
+
                     if flatSegment[0] == inputSegment.flat[0] and flatSegment[-1] != inputSegment.flat[-1]:
                         # needed the first part of the segment
                         # if previousIntersectionPoint is None:


### PR DESCRIPTION
The single E glyph in [prevint.zip](https://github.com/typemytype/booleanOperations/files/9849226/prevint.zip) exhibits a problem with `previousIntersectionPoint` tracking in `flatten.py:reCurveSubSegments()`. This is a real example from a production font but unfortunately I haven't been able to generate other similar cases synthetically. (I tried less hard with this one because the fix seemed straightforward.)

Anyway, it appears that very rarely the `previousIntersectionPoint` is not on the segment handled next. This is a particular problem for the `elif flatSegment[-1] == inputSegment.flat[-1] and flatSegment[0] != inputSegment.flat[0]:` code, which will use that point as the start of the spline if it isn't `None`.

My added code just checks to see if the `previousIntersectionPoint` is actually on the current `inputSegment` and if not sets it back to `None` so that it won't cause problems. 