### PR TITLE
Fix test compatibility with fonttools splitCubicAtT precision improvement

### DIFF
--- a/tests/testData/test.ufo/glyphs.difference/Q_.glif
+++ b/tests/testData/test.ufo/glyphs.difference/Q_.glif
@@ -16,7 +16,7 @@
       <point x="316.25401306152344" y="115.74598693847656" type="line"/>
       <point x="296.205190429384" y="105.674005342992"/>
       <point x="273.686684" y="100.0"/>
-      <point x="250.00000000000003" y="100.0" type="curve" smooth="yes"/>
+      <point x="250.0" y="100.0" type="curve" smooth="yes"/>
       <point x="168.0" y="100.0"/>
       <point x="100.0" y="168.0"/>
       <point x="100.0" y="250.0" type="curve" smooth="yes"/>
@@ -32,7 +32,7 @@
       <point x="455.01900482177734" y="106.98099517822266" type="line"/>
       <point x="483.36549467244805" y="147.495045593896"/>
       <point x="500.00000000000006" y="196.816732"/>
-      <point x="500.0" y="249.99999999999997" type="curve" smooth="yes"/>
+      <point x="500.0" y="250.0" type="curve" smooth="yes"/>
       <point x="500.0" y="388.0"/>
       <point x="388.0" y="500.0"/>
       <point x="250.0" y="500.0" type="curve" smooth="yes"/>

--- a/tests/testData/test.ufo/glyphs.difference/Q_T_ail_reversed.glif
+++ b/tests/testData/test.ufo/glyphs.difference/Q_T_ail_reversed.glif
@@ -16,7 +16,7 @@
       <point x="316.26061248779297" y="115.73938751220703" type="line"/>
       <point x="296.210179594696" y="105.675262540048"/>
       <point x="273.689308" y="100.0"/>
-      <point x="249.99999999999997" y="100.0" type="curve" smooth="yes"/>
+      <point x="250.0" y="100.0" type="curve" smooth="yes"/>
       <point x="168.0" y="100.0"/>
       <point x="100.0" y="168.0"/>
       <point x="100.0" y="250.0" type="curve" smooth="yes"/>
@@ -32,7 +32,7 @@
       <point x="455.01900482177734" y="106.98099517822266" type="line"/>
       <point x="483.36549467244805" y="147.495045593896"/>
       <point x="500.00000000000006" y="196.816732"/>
-      <point x="500.0" y="249.99999999999997" type="curve" smooth="yes"/>
+      <point x="500.0" y="250.0" type="curve" smooth="yes"/>
       <point x="500.0" y="388.0"/>
       <point x="388.0" y="500.0"/>
       <point x="250.0" y="500.0" type="curve" smooth="yes"/>

--- a/tests/testData/test.ufo/glyphs.intersection/Q_.glif
+++ b/tests/testData/test.ufo/glyphs.intersection/Q_.glif
@@ -20,7 +20,7 @@
       <point x="382.20357513427734" y="179.79642486572266" type="line"/>
       <point x="393.540909595132" y="200.78517673041398"/>
       <point x="400.0" y="224.727682"/>
-      <point x="400.00000000000006" y="250.0" type="curve" smooth="yes"/>
+      <point x="400.0" y="250.0" type="curve" smooth="yes"/>
       <point x="400.0" y="332.0"/>
       <point x="332.0" y="400.0"/>
       <point x="250.0" y="400.0" type="curve" smooth="yes"/>

--- a/tests/testData/test.ufo/glyphs.intersection/Q_T_ail_reversed.glif
+++ b/tests/testData/test.ufo/glyphs.intersection/Q_T_ail_reversed.glif
@@ -20,7 +20,7 @@
       <point x="382.20421600341797" y="179.79578399658203" type="line"/>
       <point x="393.541161083068" y="200.78610895348598"/>
       <point x="400.0" y="224.72817399999997"/>
-      <point x="400.0" y="249.99999999999997" type="curve" smooth="yes"/>
+      <point x="400.0" y="250.0" type="curve" smooth="yes"/>
       <point x="400.0" y="332.0"/>
       <point x="332.0" y="400.0"/>
       <point x="250.0" y="400.0" type="curve" smooth="yes"/>

--- a/tests/testData/test.ufo/glyphs.union/Q_.glif
+++ b/tests/testData/test.ufo/glyphs.union/Q_.glif
@@ -12,7 +12,7 @@
       <point x="455.01900482177734" y="106.98099517822266" type="line"/>
       <point x="483.36549467244805" y="147.495045593896"/>
       <point x="500.00000000000006" y="196.816732"/>
-      <point x="500.0" y="249.99999999999997" type="curve" smooth="yes"/>
+      <point x="500.0" y="250.0" type="curve" smooth="yes"/>
       <point x="500.0" y="388.0"/>
       <point x="388.0" y="500.0"/>
       <point x="250.0" y="500.0" type="curve" smooth="yes"/>
@@ -23,7 +23,7 @@
       <point x="112.0" y="0.0"/>
     </contour>
     <contour>
-      <point x="250.00000000000003" y="100.0" type="curve" smooth="yes"/>
+      <point x="250.0" y="100.0" type="curve" smooth="yes"/>
       <point x="168.0" y="100.0"/>
       <point x="100.0" y="168.0"/>
       <point x="100.0" y="250.0" type="curve" smooth="yes"/>

--- a/tests/testData/test.ufo/glyphs.union/Q_T_ail_reversed.glif
+++ b/tests/testData/test.ufo/glyphs.union/Q_T_ail_reversed.glif
@@ -20,7 +20,7 @@
       <point x="455.01900482177734" y="106.98099517822266" type="line"/>
       <point x="483.36549467244805" y="147.495045593896"/>
       <point x="500.00000000000006" y="196.816732"/>
-      <point x="500.0" y="249.99999999999997" type="curve" smooth="yes"/>
+      <point x="500.0" y="250.0" type="curve" smooth="yes"/>
       <point x="500.0" y="388.0"/>
       <point x="388.0" y="500.0"/>
       <point x="250.0" y="500.0" type="curve" smooth="yes"/>

--- a/tests/testData/test.ufo/glyphs.xor/Q_.glif
+++ b/tests/testData/test.ufo/glyphs.xor/Q_.glif
@@ -16,7 +16,7 @@
       <point x="316.25401306152344" y="115.74598693847656" type="line"/>
       <point x="296.205190429384" y="105.674005342992"/>
       <point x="273.686684" y="100.0"/>
-      <point x="250.00000000000003" y="100.0" type="curve" smooth="yes"/>
+      <point x="250.0" y="100.0" type="curve" smooth="yes"/>
       <point x="168.0" y="100.0"/>
       <point x="100.0" y="168.0"/>
       <point x="100.0" y="250.0" type="curve" smooth="yes"/>
@@ -38,7 +38,7 @@
       <point x="455.01900482177734" y="106.98099517822266" type="line"/>
       <point x="483.36549467244805" y="147.495045593896"/>
       <point x="500.00000000000006" y="196.816732"/>
-      <point x="500.0" y="249.99999999999997" type="curve" smooth="yes"/>
+      <point x="500.0" y="250.0" type="curve" smooth="yes"/>
       <point x="500.0" y="388.0"/>
       <point x="388.0" y="500.0"/>
       <point x="250.0" y="500.0" type="curve" smooth="yes"/>

--- a/tests/testData/test.ufo/glyphs.xor/Q_T_ail_reversed.glif
+++ b/tests/testData/test.ufo/glyphs.xor/Q_T_ail_reversed.glif
@@ -16,7 +16,7 @@
       <point x="316.26061248779297" y="115.73938751220703" type="line"/>
       <point x="296.210179594696" y="105.675262540048"/>
       <point x="273.689308" y="100.0"/>
-      <point x="249.99999999999997" y="100.0" type="curve" smooth="yes"/>
+      <point x="250.0" y="100.0" type="curve" smooth="yes"/>
       <point x="168.0" y="100.0"/>
       <point x="100.0" y="168.0"/>
       <point x="100.0" y="250.0" type="curve" smooth="yes"/>
@@ -38,7 +38,7 @@
       <point x="455.01900482177734" y="106.98099517822266" type="line"/>
       <point x="483.36549467244805" y="147.495045593896"/>
       <point x="500.00000000000006" y="196.816732"/>
-      <point x="500.0" y="249.99999999999997" type="curve" smooth="yes"/>
+      <point x="500.0" y="250.0" type="curve" smooth="yes"/>
       <point x="500.0" y="388.0"/>
       <point x="388.0" y="500.0"/>
       <point x="250.0" y="500.0" type="curve" smooth="yes"/>

--- a/tests/test_BooleanGlyph.py
+++ b/tests/test_BooleanGlyph.py
@@ -1,7 +1,8 @@
 from __future__ import print_function, division, absolute_import
 
-import sys
+import math
 import os
+import sys
 import unittest
 
 import pytest
@@ -12,6 +13,23 @@ import booleanOperations
 
 
 VERBOSE = False
+
+
+def _approx_equal(a, b):
+    """Check if two values are approximately equal, handling nested structures.
+
+    Uses math.isclose for float comparison to handle minor differences between
+    fonttools versions in splitCubicAtT precision.
+    """
+    if type(a) != type(b):
+        return False
+    if isinstance(a, (tuple, list)):
+        if len(a) != len(b):
+            return False
+        return all(_approx_equal(x, y) for x, y in zip(a, b))
+    if isinstance(a, float):
+        return math.isclose(a, b)
+    return a == b
 
 
 class BooleanTests(unittest.TestCase):
@@ -47,7 +65,10 @@ def _makeTestCase(glyph, booleanMethodName, args=None):
         func(*args, outPen=testPen)
         expectedPen = DigestPointPen()
         expectedGlyph.drawPoints(expectedPen)
-        self.assertEqual(testPen.getDigest(), expectedPen.getDigest(), "Glyph name '%s' failed for '%s'." % (glyph.name, booleanMethodName))
+        self.assertTrue(
+            _approx_equal(testPen.getDigest(), expectedPen.getDigest()),
+            "Glyph name '%s' failed for '%s'." % (glyph.name, booleanMethodName)
+        )
 
     return True, test
 


### PR DESCRIPTION
- Update test data to expect cleaner floating point values from splitCubicAtT
- Add approximate comparison for floating point values in test assertions

fonttools https://github.com/fonttools/fonttools/pull/3743 added a fix to splitCubicAtT that ensures the first segment starts exactly at pt1 and the last segment ends exactly at pt4, eliminating floating point drift (e.g. 250.00000000000003 → 250.0).

The booleanOperations tests were comparing glyph digests exactly, so the cleaner output from the fixed splitCubicAtT caused test failures.

I regenerated expected test data to match the latest fonttools but also changed digest comparison to use math.isclose for floats, allowing the tests to pass with both old and new fonttools versions.
